### PR TITLE
korrektur bellwert fehler

### DIFF
--- a/4.2_Test_der_Bellschen_Ungleichung_Fischer_Pfeiffer.tex
+++ b/4.2_Test_der_Bellschen_Ungleichung_Fischer_Pfeiffer.tex
@@ -181,7 +181,7 @@ wobei sich jedes einzelne $\Delta$E berechnet über
 \begin{equation}
 \Delta\,E(\alpha\,,\beta)=\sqrt{\sum_{i=1}^4\left(\frac{\delta\,E}{\delta\,N_{i}}\right)\cdot\,N_{i}}
 \end{equation}
-Damit berechnet sich der Bellwert zu $S=2,6158\pm\,0,0148$. Dieser Wert liegt zwar auch in der oberen Grenze noch um ca. 7\% von dem nach der Quantenmechanik zu erwartenden Wert von $S=2\sqrt{2}\approx\,2,8284$ jedoch liegt er etwas über das 41 Fache der Standartabweichung über dem nach einer HVT prognostizierten Wert S=2.
+Damit berechnet sich der Bellwert zu $S=2,6158\pm\,0,0162$. Dieser Wert liegt zwar auch in der oberen Grenze noch um ca. 7\% von dem nach der Quantenmechanik zu erwartenden Wert von $S=2\sqrt{2}\approx\,2,8284$ jedoch liegt er etwas über das 38 Fache der Standartabweichung über dem nach einer HVT prognostizierten Wert S=2.
 \chapter{Fazit}	
 •
 \renewcommand{\bibname}{Literatur}


### PR DESCRIPTION
hab das mit der 4 in der Ableitung korrigiert, dadurch ändert sich der fehler vom bellwert minimal @jonas-fischer 